### PR TITLE
feat: encode branches to work with slashes

### DIFF
--- a/src/app/components/repo-form/repo-form.component.ts
+++ b/src/app/components/repo-form/repo-form.component.ts
@@ -1,9 +1,8 @@
-import { animate, style, transition, trigger } from '@angular/animations';
 import { Component, Input, OnInit } from '@angular/core';
 import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
 import { UntilDestroy } from '@ngneat/until-destroy';
-import { Repository, StateService } from '../../github/state.service';
+import { StateService } from '../../github/state.service';
 
 @UntilDestroy()
 @Component({
@@ -32,7 +31,7 @@ export class RepoFormComponent implements OnInit {
     if (this.repoForm.valid) {
       this.loading = true;
       const { value } = this.repoForm;
-      this.router.navigateByUrl(`/v/${value.owner}/${value.name}/${value.branch}`);
+      this.router.navigateByUrl(`/v/${value.owner}/${value.name}/${encodeURIComponent(value.branch)}`);
     }
   }
 }

--- a/src/app/github/contents/api.service.ts
+++ b/src/app/github/contents/api.service.ts
@@ -60,7 +60,7 @@ export class ApiService {
       mergeMapNonNull(repo =>
         this.http.get<any>(`${this.bp}repos/${repo.owner}/${repo.name}`, {
           params: {
-            ref: repo.branch || 'master'
+            ref: decodeURIComponent(repo.branch || 'master')
           }
         })
       ),
@@ -71,7 +71,7 @@ export class ApiService {
       mergeMapNonNull(repo =>
         this.http.get<FileItem>(`${this.bp}repos/${repo.owner}/${repo.name}/readme`, {
           params: {
-            ref: repo.branch || 'master'
+            ref: decodeURIComponent(repo.branch || 'master')
           }
         })
       ),
@@ -80,7 +80,7 @@ export class ApiService {
     );
 
     this.branchInfo$ = this.state.repository$.pipe(
-      mergeMapNonNull(repo => this.http.get<any>(`${this.bp}repos/${repo.owner}/${repo.name}/branches/${repo.branch}`)),
+      mergeMapNonNull(repo => this.http.get<any>(`${this.bp}repos/${repo.owner}/${repo.name}/branches/${decodeURIComponent(repo.branch)}`)),
       tap(data => this.dataLookup.collect(data)),
       shareReplay(1)
     );

--- a/src/app/github/contents/content.service.ts
+++ b/src/app/github/contents/content.service.ts
@@ -26,7 +26,7 @@ export class ContentService {
           this.http.get<string>(`${this.bp}repos/${repo.owner}/${repo.name}/contents/${path}`, {
             responseType: 'text' as 'json',
             params: {
-              ref: repo.branch
+              ref: decodeURIComponent(repo.branch)
             },
             headers: {
               Accept: 'application/vnd.github.VERSION.raw'

--- a/src/app/github/state.service.ts
+++ b/src/app/github/state.service.ts
@@ -37,9 +37,13 @@ export class StateService {
       name: next.name || now.name,
       branch: next.branch || now.branch || 'master'
     };
+    if (normalized.branch.includes('/')) {
+      normalized.branch = encodeURIComponent(normalized.branch);
+    }
     if (areEqualsRepos(normalized, now)) {
       return;
     }
     this.repository$.next(normalized);
+    console.log('normalized:', normalized);
   }
 }

--- a/src/app/view/components/index.ts
+++ b/src/app/view/components/index.ts
@@ -7,3 +7,4 @@ export * from './rate/rate.component';
 export * from './repo-tree/repo-tree.component';
 export * from './top-nav/top-nav.component';
 export * from './rate-limit-reached/rate-limit-reached.component';
+export * from './switch-renderer-dialog/switch-renderer-dialog.component';

--- a/src/app/view/pages/view-page/view-page.component.html
+++ b/src/app/view/pages/view-page/view-page.component.html
@@ -17,7 +17,7 @@
           mat-button
           class="mat-button-nowrap"
         >
-          {{ repo.owner }}/{{ repo.name }}/{{ repo.branch }}
+          {{ repo.owner }}/{{ repo.name }}/{{ repo.branch | decodeURIComponent }}
           <mat-icon svgIcon="github"></mat-icon>
         </a>
       </mat-toolbar>

--- a/src/app/view/pipes/decode-uricomponent.pipe.spec.ts
+++ b/src/app/view/pipes/decode-uricomponent.pipe.spec.ts
@@ -1,0 +1,8 @@
+import { DecodeURIComponentPipe } from './decode-uricomponent.pipe';
+
+describe('DecodeURIComponentPipe', () => {
+  it('create an instance', () => {
+    const pipe = new DecodeURIComponentPipe();
+    expect(pipe).toBeTruthy();
+  });
+});

--- a/src/app/view/pipes/decode-uricomponent.pipe.ts
+++ b/src/app/view/pipes/decode-uricomponent.pipe.ts
@@ -1,0 +1,10 @@
+import { Pipe, PipeTransform } from '@angular/core';
+
+@Pipe({
+  name: 'decodeURIComponent'
+})
+export class DecodeURIComponentPipe implements PipeTransform {
+  transform(value: string): string {
+    return decodeURIComponent(value);
+  }
+}

--- a/src/app/view/pipes/index.ts
+++ b/src/app/view/pipes/index.ts
@@ -4,3 +4,4 @@ export * from './raw-content-link.pipe';
 export * from './opened-files-max-width.pipe';
 export * from './mins-diff.pipe';
 export * from './item-info-by-sha.pipe';
+export * from './decode-uricomponent.pipe';

--- a/src/app/view/view.module.ts
+++ b/src/app/view/view.module.ts
@@ -13,14 +13,22 @@ import {
   RateComponent,
   RateLimitReachedComponent,
   RepoTreeComponent,
+  SwitchRendererDialogComponent,
   TopNavComponent
 } from './components';
 import { FilePageComponent, ViewPageComponent } from './pages';
-import { FormatBytesPipe, GithubLinkPipe, ItemInfoByShaPipe, MinsDiffPipe, OpenedFilesMaxWidthPipe, RawContentLinkPipe } from './pipes';
+import {
+  DecodeURIComponentPipe,
+  FormatBytesPipe,
+  GithubLinkPipe,
+  ItemInfoByShaPipe,
+  MinsDiffPipe,
+  OpenedFilesMaxWidthPipe,
+  RawContentLinkPipe
+} from './pipes';
 import { ScrollRestorationService } from './scroll-restoration.service';
 
 import { ViewRoutingModule } from './view-routing.module';
-import { SwitchRendererDialogComponent } from './components/switch-renderer-dialog/switch-renderer-dialog.component';
 
 @NgModule({
   declarations: [
@@ -41,7 +49,8 @@ import { SwitchRendererDialogComponent } from './components/switch-renderer-dial
     RawContentLinkPipe,
     MinsDiffPipe,
     ItemInfoByShaPipe,
-    SwitchRendererDialogComponent
+    SwitchRendererDialogComponent,
+    DecodeURIComponentPipe
   ],
   imports: [CommonModule, ViewRoutingModule, FormsModule, MaterialModule, CodemirrorModule, MarkdownModule.forChild()],
   entryComponents: [RateLimitReachedComponent, SwitchRendererDialogComponent],


### PR DESCRIPTION
This currently only works from the form from the home page. The redirect cannot determine what part is the branch. The GitHub API does not expose an endpoint to reliably provide a list of all branches. Technically it would be possible to iterate over every possible branch name from the given path in the URL and send a request and check for a 404 or 200 status, but this is currently not implemented.